### PR TITLE
Fix sprintf error on 32-bit builds

### DIFF
--- a/camera/output/net_output.cpp
+++ b/camera/output/net_output.cpp
@@ -153,7 +153,7 @@ void NetOutput::outputUnixSocket(void *mem, size_t size, int64_t timestamp_us, u
 
 	// Prepare the header string with topic and number of bytes that follow the line break
 	char header[100] = "";
-	sprintf(header, "PUB frame.jpeg %lu\r\n", size);
+	sprintf(header, "PUB frame.jpeg %lu\r\n", static_cast<unsigned long>(size));
 
 	// if (options_->verbose)
 	// 	std::cerr << "NetOutput: output buffer " << mem << " size " << size << "\n";
@@ -195,7 +195,7 @@ void NetOutput::outputBuffer(void *mem, size_t size, int64_t timestamp_us, uint3
 
 	// Prepare the header string with topic and number of bytes that follow the line break
 	char header[100] = "";
-	sprintf(header, "PUB frame.jpeg %lu\r\n", size);
+	sprintf(header, "PUB frame.jpeg %lu\r\n", static_cast<unsigned long>(size));
 
 	size_t bytes_to_send = std::min(size, max_size - header_length);
 	uint8_t *ptr = (uint8_t *)mem;


### PR DESCRIPTION
I guess 32-bt treats a size_t as different from an unsigned long.  This change upcasts the size_t which if fine for 32-bit and is a no-op on 64-bit.  64-bit builds fine with this change as well.

Fixes the following error:

net_output.cpp: In member function ‘void NetOutput::outputUnixSocket(void*, size_t, int64_t, uint32_t)’:
net_output.cpp:156:36: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
  156 |  sprintf(header, "PUB frame.jpeg %lu\r\n", size);
      |                                  ~~^       ~~~~
      |                                    |       |
      |                                    |       size_t {aka unsigned int}
      |                                    long unsigned int
      |                                  %u
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
