### PR TITLE
Install the CPP binary

### DIFF
--- a/camera/CMakeLists.txt
+++ b/camera/CMakeLists.txt
@@ -54,3 +54,5 @@ add_executable(libcamera-bridge app.cpp)
 target_link_libraries(libcamera-bridge libcamera_app encoders outputs)
 
 set(EXECUTABLES libcamera-bridge)
+
+install(TARGETS ${EXECUTABLES} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Tested this on the target where libcamera-bridge gets installed to /usr/bin by default, but can be redirected using CMAKE_INSTALL_PREFIX.  So this change meets our needs I think.